### PR TITLE
Use JSON::PP not new dependency JSON

### DIFF
--- a/lib/Lab/Moose/Instrument/Bluefors_Temp.pm
+++ b/lib/Lab/Moose/Instrument/Bluefors_Temp.pm
@@ -20,7 +20,7 @@ use Time::HiRes qw/time usleep/;
 
 # HTTP request JSON stuff
 use DateTime;
-use JSON;
+use JSON::PP;
 use Data::Dumper;
 
 =head1 SYNOPSIS
@@ -64,7 +64,7 @@ has json => (
     builder => '_build_json',
 );
 sub _build_json {
-    return JSON->new;
+    return JSON::PP->new;
 }
 
 around default_connection_options => sub {
@@ -190,9 +190,9 @@ sub set_heater {
     );
     if (exists $args{'active'} and defined $args{'active'}) {
         if ( $args{"active"} eq 1 ) {
-            $args{"active"} = JSON::true;
+            $args{"active"} = JSON::PP::true;
         } else {
-            $args{"active"} = JSON::false;
+            $args{"active"} = JSON::PP::false;
         }
     }
     my $json = $self->json->encode(\%args);
@@ -237,9 +237,9 @@ sub set_channel {
     );
     if (exists $args{'active'} and defined $args{'active'}) {
         if ( $args{"active"} eq 1 ) {
-            $args{"active"} = JSON::true;
+            $args{"active"} = JSON::PP::true;
         } else {
-            $args{"active"} = JSON::false;
+            $args{"active"} = JSON::PP::false;
         }
     }
     my $json = $self->json->encode(\%args);


### PR DESCRIPTION
Without this change, `00-load.t` fails. Please merge and release it, as this is currently breaking PDL's downstream-dependencies CI. I don't know how it passed yours, since it looks like the Bluefors file last got modified last year.

This is none of my business, but I see you have a lot of branches that are quite old; it might be beneficial to delete those?